### PR TITLE
Check for NULL token type in scanf callback

### DIFF
--- a/frozen.c
+++ b/frozen.c
@@ -868,7 +868,7 @@ static void json_scanf_cb(void *callback_data, const char *name,
     return;
   }
 
-  if (token->ptr == NULL) {
+  if (token->ptr == NULL || token->type == JSON_TYPE_NULL) {
     /*
      * We're not interested here in the events for which we have no value;
      * namely, JSON_TYPE_OBJECT_START and JSON_TYPE_ARRAY_START

--- a/unit_test.c
+++ b/unit_test.c
@@ -547,6 +547,14 @@ static const char *test_scanf(void) {
     free(result);
   }
 
+  {
+    const char *str = "{a : null }";
+    char *result = NULL;
+    ASSERT(json_scanf(str, strlen(str), "{a: %Q}", &result) == 0);
+    ASSERT(result == NULL);
+    free(result);
+  }
+  
   return NULL;
 }
 


### PR DESCRIPTION
Fix for issue #16 
Check for NULL token in the scanf callback and return immediately to fail conversion,