### PR TITLE
add recursion depth limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,38 @@ If top-level element is an array: `[1, {"foo": 2}]`
 If top-level element is a scalar: `true`
 - type: `JSON_TYPE_TRUE`, name: `NULL`, path: `""`, value: `"true"`
 
+## `json_walk_args()` - low level parsing API extensible interface
+
+This function is identical to json_walk() except that it takes a
+struct pointer argument for the `callback` and `callback_data`
+arguments and additional configuration elements:
+
+```
+struct frozen_args {
+  json_walk_callback_t callback;
+  void *callback_data;
+  int limit;
+};
+```
+
+This struct must be initialized using `INIT_FROZEN_ARGS()` to retain
+forward compatibility before any members are set as illustrated here:
+
+```
+struct frozen_args args[1];
+
+INIT_FROZEN_ARGS(args);
+
+args->callback = mycb;
+args->callback_data = data;
+args->limit = 20;
+
+ret = json_walk_args(string, len, args);
+```
+
+the `limit` member of `struct frozen_args` can be set to limit the
+maximum recursion depth to prevent possible stack overflows and limit
+parsing complexity.
 
 ## `json_fprintf()`, `json_vfprintf()`
 

--- a/frozen.h
+++ b/frozen.h
@@ -26,6 +26,7 @@ extern "C" {
 #include <stdarg.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <limits.h>
 
 #if defined(_WIN32) && _MSC_VER < 1700
 typedef int bool;
@@ -66,6 +67,7 @@ struct json_token {
 /* Error codes */
 #define JSON_STRING_INVALID -1
 #define JSON_STRING_INCOMPLETE -2
+#define JSON_DEPTH_LIMIT -3
 
 /*
  * Callback-based SAX-like API.
@@ -104,6 +106,24 @@ typedef void (*json_walk_callback_t)(void *callback_data, const char *name,
  */
 int json_walk(const char *json_string, int json_string_length,
               json_walk_callback_t callback, void *callback_data);
+
+/*
+ * Extensible argument passing interface
+ */
+
+struct frozen_args {
+  json_walk_callback_t callback;
+  void *callback_data;
+  int limit;
+};
+
+int json_walk_args(const char *json_string, int json_string_length,
+		   const struct frozen_args *args);
+
+#define INIT_FROZEN_ARGS(ptr) do {			\
+		memset((ptr), 0, sizeof(*(ptr)));	\
+		(ptr)->limit = INT_MAX;		\
+	} while(0)
 
 /*
  * JSON generation API.

--- a/unit_test.c
+++ b/unit_test.c
@@ -138,6 +138,16 @@ static const char *test_errors(void) {
   ASSERT(json_walk("{}", 2, NULL, NULL) == 2);
   ASSERT(json_walk(s1, strlen(s1), NULL, 0) > 0);
 
+  {
+    const char *sl = "{ a: [[[[[[[[";
+    struct frozen_args args[1];
+
+    INIT_FROZEN_ARGS(args);
+    args->limit = 10;
+
+    ASSERT(json_walk_args(sl, strlen(sl), args) == JSON_DEPTH_LIMIT);
+    ASSERT(json_walk_args(sl, strlen(sl) - 1, args) == JSON_STRING_INCOMPLETE);
+  }
   return NULL;
 }
 


### PR DESCRIPTION
for validating untrusted inputs, we need to limit the recursion depth in order to avoid running into stack overflows.

We also introduce a new extensible API interface: `json_walk_args()` takes additional arguments in the form of a struct which can be extended easily and in a backwards-compatible manner.