### PR TITLE
fix "%g" and "%e" in json_printf and json_printf_array

### DIFF
--- a/frozen.c
+++ b/frozen.c
@@ -641,7 +641,7 @@ int json_vprintf(struct json_out *out, const char *fmt, va_list xap) {
          * TODO(dfrank): reimplement %s and %.*s in order to avoid that.
          */
 
-        const char *end_of_format_specifier = "sdfFgGlhuIcx.*-0123456789";
+        const char *end_of_format_specifier = "sdfFeEgGlhuIcx.*-0123456789";
         int n = strspn(fmt + 1, end_of_format_specifier);
         char *pbuf = buf;
         int need_len, size = sizeof(buf);
@@ -769,7 +769,7 @@ int json_printf_array(struct json_out *out, va_list *ap) {
     memcpy(&val, arr + i * elem_size,
            elem_size > sizeof(val) ? sizeof(val) : elem_size);
     if (i > 0) len += json_printf(out, ", ");
-    if (strchr(fmt, 'f') != NULL) {
+    if (strpbrk(fmt, "efg") != NULL) {
       len += json_printf(out, fmt, val.d);
     } else {
       len += json_printf(out, fmt, val.i);

--- a/unit_test.c
+++ b/unit_test.c
@@ -345,6 +345,22 @@ static const char *test_json_printf(void) {
     ASSERT(strcmp(buf, result) == 0);
   }
 
+  {
+    struct json_out out = JSON_OUT_BUF(buf, sizeof(buf));
+    double arr[] = {9.32156, 3.1415926};
+    json_printf(&out, "%M", json_printf_array, arr, sizeof(arr), sizeof(arr[0]),
+                "%.2e");
+    ASSERT(strcmp(buf, "[9.32e+00, 3.14e+00]") == 0);
+  }
+
+  {
+    struct json_out out = JSON_OUT_BUF(buf, sizeof(buf));
+    double arr[] = {9.32156, 3.1415926};
+    json_printf(&out, "%M", json_printf_array, arr, sizeof(arr), sizeof(arr[0]),
+                "%.4g");
+    ASSERT(strcmp(buf, "[9.322, 3.142]") == 0);
+  }
+
   return NULL;
 }
 


### PR DESCRIPTION
- `json_printf_array()` only recognised `"%f"` as requiring a double argument; add `'e'` and `'g'` to the list and use `strpbrk()` to recognise them all
- when delegating to system printf, `json_vprintf()` didn't expect `"eE"` to end format specifiers; add them to the list
- add new unit tests utilizing `"%g"` and `"%e"` formats in `json_printf_array()`