### PR TITLE
process %s and %.*s internally in json_vprintf()

### DIFF
--- a/frozen.c
+++ b/frozen.c
@@ -629,6 +629,25 @@ int json_vprintf(struct json_out *out, const char *fmt, va_list xap) {
           len += json_escape(out, p, l);
           len += out->printer(out, quote, 1);
         }
+      } else if (fmt[1] == 's' ||
+                 (fmt[1] == '.' && fmt[2] == '*' && fmt[3] == 's')) {
+        size_t l = 0;
+        const char *p;
+
+        if (fmt[1] == '.') {
+          l = (size_t) va_arg(ap, int);
+          skip += 2;
+        }
+        p = va_arg(ap, char *);
+
+        if (p == NULL) {
+          len += out->printer(out, null, 4);
+        } else {
+          if (fmt[1] == 's') {
+            l = strlen(p);
+          }
+          len += out->printer(out, p, l);
+        }
       } else {
         /*
          * we delegate printing to the system printf.
@@ -636,9 +655,9 @@ int json_vprintf(struct json_out *out, const char *fmt, va_list xap) {
          * printf, as you can see below we still have to parse the format
          * types.
          *
-         * Currently, %s with strings longer than 20 chars will require
-         * double-buffering (an auxiliary buffer will be allocated from heap).
-         * TODO(dfrank): reimplement %s and %.*s in order to avoid that.
+         * format string / arguments combinations that result in outputs longer
+         * than 20 chars will require double-buffering (an auxiliary buffer will
+         * be allocated from heap).
          */
 
         const char *end_of_format_specifier = "sdfFeEgGlhuIcx.*-0123456789";


### PR DESCRIPTION
large strings (> 20 chars) need an additional allocation of memory
in order to provide a large enough buffer to be processed with
vsnprintf(). With this patch %s and %.*s are processed internally
in json_vprintf() and not delegated to vsnprintf() anymore. So in
theory json_vprintf() should work without calling malloc().
Nevertheless the delegating section to vnsprintf() stays intact
for any other format strings / argument combinations that could
produce outputs of longer than 20 chars.