### PR TITLE
json_unescape(): Add basic UTF-8 support

### DIFF
--- a/unit_test.c
+++ b/unit_test.c
@@ -595,6 +595,31 @@ static const char *test_scanf(void) {
     ASSERT(strcmp(result, "привет") == 0);
     free(result);
   }
+  
+  {
+	/* Test invalid (less than 4 bytes) utf8-code */
+	const char *str = "{a : \"\x5Cuabc\" }";
+	char *result;
+	ASSERT(json_scanf(str, strlen(str), "{a: %Q}", &result) == 0);
+  }
+
+  {
+	/* Test invalid (non-hex) utf8-code */
+	const char *str = "{a : \"\x5CuWXYZ\" }";
+	char *result;
+	ASSERT(json_scanf(str, strlen(str), "{a: %Q}", &result) == 0);
+  }
+  
+  {
+    /* Test basic utf-8 handling */
+    //bypass UTF-8 decoding of compiler by using '\x5C' for backslash
+    const char *str = "{a : \"\x5CuC384\x5Cu0041\x5Cu0007\" }";
+    char *result;
+
+    ASSERT(json_scanf(str, strlen(str), "{a: %Q}", &result) == 1);
+    ASSERT(strcmp(result, "\x5CuC384A\x5Cu0007") == 0);
+    free(result);
+  }
 #if JSON_ENABLE_BASE64
   {
     const char *str = "{a : \"YTI=\" }";


### PR DESCRIPTION
When calling a json_scanf() with a %Q format specifier unescaping of
\u0020 to \u007F was added. Other unicodes in the format \uXXXX.. are
bypassed directly to the result string. This way unescaping should be
compliant with JSON RFC4627 Section 2.5 (Strings)