### PR TITLE
add meson support for eased cross-compilation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,25 @@
+project(
+    'frozen',
+    'c',
+    default_options: [
+        'c_args=-Wextra -fno-builtin -pedantic',
+        'c_std=c99',
+        'werror=true'
+    ],
+    license: 'Apache-2.0',
+    version: '1.7'
+)
+
+libfrozen = library(
+    'frozen',
+    'frozen.c',
+    install: true
+)
+install_headers('frozen.h')
+
+unit_test = executable('unit_test',
+    'unit_test.c',
+    dependencies: [libfrozen]
+)
+test('Frozen Unit Test', unit_test)
+


### PR DESCRIPTION
In the past I mostly cross-compiled frozen from hand and copy-pasted it inside the needed application.

This patch adds a meson build definition, which already has builtin cross-compilation support. My aim is to use this in cross-compiled NixOS pkgs as a dependency without copy-paste and manual cross-compilation.