### PR TITLE
Add a .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+
+# build artifacts from use as a submodule with autotools
+.deps
+.dirstamp
+.libs
+frozen.lo
+frozen.o
+
+# build artifacts from make
+unit_test*
+frozen.c.gcov


### PR DESCRIPTION
This initial version instructs git to ignore build artifacts from the environment which I am using. Your environment might leave different artifacts, in which case the file might need to be extended.

This is particularly relevant for use as a submodule, which otherwise is always shown as dirty after a build.